### PR TITLE
Determine template directory from script location - Issue #4

### DIFF
--- a/bin/generate_number_puzzle.pl
+++ b/bin/generate_number_puzzle.pl
@@ -21,14 +21,14 @@ die $usage unless GetOptions(
 $datafile ||= 'puzzle-numbers01.dat';
 my $backup_datafile = 'data/addition_to_10-bkp.dat';
 
-my $template_config = {
-	INCLUDE_PATH    => ["../."],
-};
-
-my $data_dir = "$Bin/../data/";
-my $puzzle_config = $data_dir . $datafile;
+my $base_dir = "$Bin/../";
+my $puzzle_config = $base_dir . "data/" . $datafile;
 my $puzzle = SCP::PuzzleGenerator->new({ config_datafile => $puzzle_config });
 $puzzle->generate();
+
+my $template_config = {
+	INCLUDE_PATH    => [ $base_dir ],
+};
 
 my $meta = $puzzle->puzzle_meta;
 my $formulas = $puzzle->problems;


### PR DESCRIPTION
The problem I am trying to solve here is to allow `generate_number_puzzle.pl` to work from either the git root directory, or if you are within the `bin` directory. The existing code uses `INCLUDE_PATH    => ["../."],` which means that the include path is relative to the directory you are in when you run the commands. So if you change directory, it may not work. 

We already have a solution in the file to find and use the lib area regardless of which directory you run the script from . The code below says 'figure out where I am, and assign the name of the current directory to `$Bin`

```perl
 use FindBin qw/$Bin/;
 use lib "$Bin/../lib";
```

Since we know that the script will be in the `./bin/` directory underneath the git root, we can set the base path to be `my $base_dir = "$Bin/../";` then if we need to reference a particular directory we can do it.

Once this is merged, we can resolve issue #4 as this technique prevents is needing a config file (yet)