### PR TITLE
Split out the COPY commands in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ COPY SCP-WebApp/cpanfile /opt/app/
 
 RUN cpanm --installdeps /opt/app/ && apt-get update && apt-get install -y texlive
 
-COPY puzzle.tt SCP-WebApp/ lib/ /opt/app/
+COPY puzzle.tt SCP-WebApp/ /opt/app/
+COPY lib/ /opt/app/lib/
 COPY data /opt/app/data/
 
 ENV RAPI_PSGI_PORT 50000


### PR DESCRIPTION
This is needed as COPY doesn't copy a directory. Only the files in the directory.